### PR TITLE
Add jmap redirect

### DIFF
--- a/melib/src/backends/jmap.rs
+++ b/melib/src/backends/jmap.rs
@@ -24,6 +24,7 @@ use crate::conf::AccountSettings;
 use crate::email::*;
 use crate::error::{MeliError, Result};
 use futures::lock::Mutex as FutureMutex;
+use isahc::config::RedirectPolicy;
 use isahc::prelude::HttpClient;
 use isahc::ResponseExt;
 use serde_json::Value;

--- a/melib/src/backends/jmap/connection.rs
+++ b/melib/src/backends/jmap/connection.rs
@@ -35,6 +35,7 @@ impl JmapConnection {
     pub fn new(server_conf: &JmapServerConf, store: Arc<Store>) -> Result<Self> {
         let client = HttpClient::builder()
             .timeout(std::time::Duration::from_secs(10))
+            .redirect_policy(RedirectPolicy::Limit(10))
             .authentication(isahc::auth::Authentication::basic())
             .credentials(isahc::auth::Credentials::new(
                 &server_conf.server_username,


### PR DESCRIPTION
Meli currently uses the `.well-known/jmap` URL and the RFC8620 requires that any redirects are followed (https://tools.ietf.org/html/rfc8620#section-2.2). This small change allows redirects to happen.

I've been trying to get meli to work with cyrus and this is the first step for that. Unfortunately there is still the issue that Cyrus does not publish the `eventSourceUrl` (which I think goes against the RFC), so meli fails at JSON parsing. Could issues be enabled to track this?