### PR TITLE
Fix the links to the screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Community links:
 
 | | | |
 :---:|:---:|:---:
-![Main view screenshot](./docs/screenshots/main.webp "mail meli view screenshot")  |  ![Compact main view screenshot](./docs/screenshots/compact.webp "compact main view screenshot") | ![Compose with embed terminal editor screenshot](./docs/screenshots/compose.webp "composing view screenshot")
+![Main view screenshot](./docs/screenshots/main.webp?raw=true "mail meli view screenshot")  |  ![Compact main view screenshot](./docs/screenshots/compact.webp?raw=true "compact main view screenshot") | ![Compose with embed terminal editor screenshot](./docs/screenshots/compose.webp?raw=true "composing view screenshot")
 Main view             |  Compact main view | Compose with embed terminal editor
 
 Main repository:


### PR DESCRIPTION
Now each link opens the image itself but not a GitHub page for the file.