### PR TITLE
pager: fallback to syntect as syntax highligther

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ termion = { version = "1.5.1", default-features = false }
 toml = { version = "0.5.6", default-features = false, features = ["preserve_order", ] }
 unicode-segmentation = "1.2.1" # >:c
 xdg = "2.1.0"
+syntect = { version = "5.0" }
 
 [target.'cfg(target_os="linux")'.dependencies]
 notify-rust = { version = "^4", default-features = false, features = ["dbus", ], optional = true }


### PR DESCRIPTION
Fallback to use syntect library as syntax highlighter if no pager is defined in the meli config.

Signed-off-by: Guillaume Ranquet <granquet@baylibre.com>