### PR TITLE
config_macros.rs: fix build error with quote 1.0.28

### DIFF
--- a/config_macros.rs
+++ b/config_macros.rs
@@ -26,6 +26,7 @@ use std::{
 };
 
 use quote::{format_ident, quote};
+extern crate proc_macro;
 
 // Write ConfigStructOverride to overrides.rs
 pub fn override_derive(filenames: &[(&str, &str)]) {
@@ -111,7 +112,7 @@ use melib::HeaderName;
                         .iter()
                         .filter_map(|f| {
                             let mut new_attr = f.clone();
-                            if let quote::__private::TokenTree::Group(g) =
+                            if let proc_macro2::TokenTree::Group(g) =
                                 f.tokens.clone().into_iter().next().unwrap()
                             {
                                 let attr_inner_value = f.tokens.to_string();


### PR DESCRIPTION
With quote 1.0.28 the TokenTree enum is declared as a private enum thus causing this error at build time:

error[E0603]: enum `TokenTree` is private
   --> config_macros.rs:114:54
    |
114 | ...                   if let quote::__private::TokenTree::Group(g) =
    |                                                ^^^^^^^^^ private enum

Use enum definition from proc_macro2 instead.