### PR TITLE
conf/shortcuts: implement a key to command mapping

### DIFF
--- a/meli/src/conf/shortcuts.rs
+++ b/meli/src/conf/shortcuts.rs
@@ -88,6 +88,12 @@ impl DotAddressable for Shortcuts {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandShortcut {
+    pub shortcut: Key,
+    pub command: String,
+}
+
 /// Create a struct holding all of a Component's shortcuts.
 #[macro_export]
 macro_rules! shortcut_key_values {
@@ -100,6 +106,7 @@ macro_rules! shortcut_key_values {
         #[serde(default)]
         #[serde(rename = $cname)]
         pub struct $name {
+            pub commands: Vec<CommandShortcut>,
             $(pub $fname : Key),*
         }
 
@@ -122,6 +129,7 @@ macro_rules! shortcut_key_values {
         impl Default for $name {
             fn default() -> Self {
                 Self {
+                    commands : vec![],
                     $($fname: $default),*
                 }
             }

--- a/meli/src/mail/listing.rs
+++ b/meli/src/mail/listing.rs
@@ -1940,6 +1940,25 @@ impl Component for Listing {
                         self.component.set_dirty(true);
                         return true;
                     }
+                    UIEvent::Input(ref key) => {
+                        return context
+                            .settings
+                            .shortcuts
+                            .listing
+                            .commands
+                            .iter()
+                            .any(|cmd| {
+                                if cmd.shortcut == *key {
+                                    for cmd in cmd.command.split(';') {
+                                        context
+                                            .replies
+                                            .push_back(UIEvent::Command(cmd.to_string()));
+                                    }
+                                    return true;
+                                }
+                                false
+                            });
+                    }
                     _ => return false,
                 }
                 return true;


### PR DESCRIPTION
Permits users to map keys in their configuration file to meli commands

e.g:
[shortcuts.listing]
commands = [ { command = "tag remove trash; flag unset trash", shortcut = "D" },
             { command = "tag add trash; flag set trash", shortcut = "d" } ]