### PR TITLE
doc(meli.1): add manage-jobs command

### DIFF
--- a/meli/docs/meli.1
+++ b/meli/docs/meli.1
@@ -657,6 +657,8 @@ Reloads configuration but only if account configuration is unchanged.
 Useful if you want to reload some settings without restarting
 .Nm Ns
 \&.
+.It Cm manage-jobs
+List the background jobs run by meli.
 .El
 .Sh EXIT STATUS
 .Nm


### PR DESCRIPTION
I noticed the commande "manage-jobs" mentioned in  https://github.com/orgs/meli/discussions/36#discussioncomment-11729932 was missing from manpage.
And since command mode has no `:help` or autocompletion it's important to write it down somewhere.
I hesitated to order alphabetically the commands, I dont know what is a good practice for manpage.