### PR TITLE
feat: show loading progress

### DIFF
--- a/meli/src/mail/listing.rs
+++ b/meli/src/mail/listing.rs
@@ -2893,6 +2893,11 @@ impl Component for Listing {
                     .count()
                     .ok()
                     .unwrap_or((0, 0));
+                let status_str = match account[&mailbox_hash].status {
+                    MailboxStatus::Parsing (doing, done) => format!("(Loading {}/{})", doing, done),
+                    MailboxStatus::Failed (..) => "Failed".to_string(),
+                    _ => "".to_string()
+                };
                 format!(
                     "Mailbox: {}, Messages: {}, New: {}{}",
                     account[&mailbox_hash].name(),


### PR DESCRIPTION
I sometimes wonder if meli is stuck because it keeps displaying "Loading...". 
The intent here is to show what it's loading to help the user understand what's going on.

On my desktop I've got 150k emails in my notmuch db and in my case it seems it runs 150k `fetch-mailbox-continued` which I dont know what it does. It seems it fetches the "envelopes" aka the "headers" of an email ? 
Sorry I am a noob concerning rust/mail specs.
According to doc, I thought my PR would display `Loading 130/156000` but it shows `Loading 130/0` for a notmuch backend.

Is is necessary to load all the headers ? I usually just look at the new ones.